### PR TITLE
Fix to use X10 release 2.5.3

### DIFF
--- a/Queue.x10
+++ b/Queue.x10
@@ -5,6 +5,7 @@ import x10.util.Box;
 import x10.util.concurrent.Lock;
 import x10.util.StringBuilder;
 import x10.util.Team;
+import x10.xrx.Runtime;
 
 import glb.Context;
 import glb.GLBResult;

--- a/glb/GLB.x10
+++ b/glb/GLB.x10
@@ -3,6 +3,7 @@ package glb;
 import x10.util.Team;
 import x10.util.StringBuilder;
 import x10.compiler.Inline;
+import x10.xrx.Runtime;
 
 /**
  * <p>The top level class of the Global Load Balancing (GLB) framework.
@@ -12,7 +13,7 @@ public final class GLB[Queue, R]{Queue<:TaskQueue[Queue, R], R<:Arithmetic[R]} {
 	/**
 	 * Number of places.
 	 */
-	private val P = Place.MAX_PLACES;
+	private val P = Place.numPlaces();
 	/**
 	 * Home PlaceLocalHandle of {@link Worker}
 	 */
@@ -55,7 +56,7 @@ public final class GLB[Queue, R]{Queue<:TaskQueue[Queue, R], R<:Arithmetic[R]} {
 	public def this(init:()=>Queue, glbParams:GLBParameters, tree:Boolean) {
 		this.glbParams = glbParams;
 		setupTime = System.nanoTime();
-		plh = PlaceLocalHandle.makeFlat[Worker[Queue, R]](PlaceGroup.WORLD, 
+		plh = PlaceLocalHandle.makeFlat[Worker[Queue, R]](Place.places(), 
 				()=>new Worker[Queue, R](init, glbParams.n, glbParams.i, glbParams.li, glbParams.w, glbParams.l, glbParams.z, glbParams.m, tree));
 		Worker.initContexts[Queue, R](plh);
 		setupTime = System.nanoTime() - setupTime;
@@ -197,7 +198,7 @@ public final class GLB[Queue, R]{Queue<:TaskQueue[Queue, R], R<:Arithmetic[R]} {
 		});
         */
 
-        val it = PlaceGroup.WORLD.iterator();
+        val it = Place.places().iterator();
         finish while (it.hasNext()) {
             val p:Place = it.next();
             if (p != here) at (p) async {
@@ -223,7 +224,7 @@ public final class GLB[Queue, R]{Queue<:TaskQueue[Queue, R], R<:Arithmetic[R]} {
         Console.OUT.println("\"user log\" : [");
         val sbLog = new StringBuilder();
         val sbLogG = new GlobalRef[StringBuilder](sbLog);
-		for(var i:Long =0; i < Place.MAX_PLACES; ++i){
+		for(var i:Long =0; i < Place.numPlaces(); ++i){
             val b = i>0;
 			at(Place(i)){
                 val sbl = new StringBuilder();

--- a/glb/GLBParameters.x10
+++ b/glb/GLBParameters.x10
@@ -31,7 +31,7 @@ public struct GLBParameters(
     /**
      * Returns a default glb parameter
      */
-    public static Default = GLBParameters(100n,0.1,0.1,4n,4n,computeZ(Place.MAX_PLACES,4n),1024n,15n);
+    public static Default = GLBParameters(100n,0.1,0.1,4n,4n,computeZ(Place.numPlaces(),4n),1024n,15n);
     
     /**
      * Show computation result.

--- a/glb/Logger.x10
+++ b/glb/Logger.x10
@@ -3,6 +3,7 @@ package glb;
 import x10.util.ArrayList;
 import x10.util.HashMap;
 import x10.util.StringBuilder;
+import x10.xrx.Runtime;
 
 /**
  * <p>Class that collects lifeline statistics of GLB

--- a/glb/Worker.x10
+++ b/glb/Worker.x10
@@ -4,6 +4,8 @@ import x10.compiler.*;
 import x10.util.Option;
 import x10.util.OptionsParser;
 import x10.util.Random;
+import x10.xrx.Runtime;
+
 /**
  * The local runner for the GLB framework. An instance of this class runs at each
  * place and provides the context within which user-specified tasks execute and
@@ -61,7 +63,7 @@ final class Worker[Queue, R]{Queue<:TaskQueue[Queue, R]} {
     @x10.compiler.Volatile transient var waiting:Boolean = false;
     
     /* Number of places.*/
-    val P = Place.MAX_PLACES;
+    val P = Place.numPlaces();
     
     /*Context object accessible to user code, which can be used to yield.*/
     var context:Context[Queue, R];
@@ -399,7 +401,7 @@ final class Worker[Queue, R]{Queue<:TaskQueue[Queue, R]} {
      * @param st PLH of Worker
      */
     static def broadcast[Queue, R](st:PlaceLocalHandle[Worker[Queue, R]]){Queue<:TaskQueue[Queue, R]} {
-        val P = Place.MAX_PLACES;
+        val P = Place.numPlaces();
         @Pragma(Pragma.FINISH_DENSE) finish {
             if (P < 256) {
                 for(var i:Long=0; i<P; i++) {
@@ -423,7 +425,7 @@ final class Worker[Queue, R]{Queue<:TaskQueue[Queue, R]} {
      * @param st: PLH of Worker
      */
     static def initContexts[Queue,R](st:PlaceLocalHandle[Worker[Queue, R]]){Queue<:TaskQueue[Queue, R]}{
-    	val P = Place.MAX_PLACES;
+    	val P = Place.numPlaces();
     	@Pragma(Pragma.FINISH_DENSE) finish {
     		if (P < 256) {
     			for(var i:Long=0; i<P; i++) {


### PR DESCRIPTION
Added "import x10.xrx.Runtime", used "Place.numPlaces()" instead of "Place.MAX_PLACES", and used "Place.places()" instead of "PlaceGroup.WORLD".
